### PR TITLE
nklib_util:strip fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ compile:
 deps:
 	./rebar get-deps
 
-clean: 
+clean:
 	./rebar clean
 
 distclean: clean
@@ -25,6 +25,17 @@ shell:
 	erl -pa deps/lager/ebin -pa deps/goldrush/ebin -pa deps/jsx/ebin -pa deps/jiffy/ebin \
 	    -pa ebin -s nklib_app
 
+EDOC_OPTS = '[{source_path,["./src"]},\
+ 			{dir,"./edocs"}, \
+			{private,true}, \
+			{todo,true} \
+			]'
+
+edocs: edocsclean
+	erl -noshell -run edoc_run packages '[""]' $(EDOC_OPTS)
+
+edocsclean:
+	rm -Rf edocs
 
 docs:
 	./rebar skip_deps=true doc
@@ -33,20 +44,19 @@ APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
 COMBO_PLT = $(HOME)/.$(REPO)_combo_dialyzer_plt
 
-check_plt: 
+check_plt:
 	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS)
 
-build_plt: 
-	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS) 
+build_plt:
+	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS)
 
 dialyzer:
 	dialyzer -Wno_return --plt $(COMBO_PLT) ebin/nklib*.beam
 
 cleanplt:
-	@echo 
+	@echo
 	@echo "Are you sure?  It takes about 1/2 hour to re-build."
 	@echo Deleting $(COMBO_PLT) in 5 seconds.
-	@echo 
+	@echo
 	sleep 5
 	rm $(COMBO_PLT)
-

--- a/docs/nklib_util.md
+++ b/docs/nklib_util.md
@@ -1,0 +1,107 @@
+# nklib_util
+
+
+
+### append_max/3
+### apply/3
+### bin_last/2
+### bjoin/1
+### bjoin/2
+### call/2
+### call/3
+### cancel_timer/1
+### capitalize/1
+### defaults/2
+### delete/2
+### demonitor/1
+### ensure_all_started/2
+### extract/2
+### filter_values/2
+### filtermap/2
+### get_binary/2
+### get_binary/3
+### get_integer/2
+### get_integer/3
+### get_list/2
+### get_list/3
+### get_value/2
+### get_value/3
+### gmt_to_timestamp/1
+### hash/1
+### hash36/1
+### hex/1
+### is_string/1
+### keys/1
+### l_timestamp_to_float/1
+### l_timestamp/0
+### lhash/1
+### local_to_timestamp/1
+### luid/0
+### msg/2
+### randomize/1
+### remove_values/2
+### safe_call/3
+### sha/1
+### store_value/2
+### store_value/3
+### store_values/2
+
+### strip/1
+> Strips trailing white space  
+  NOTE: Really strips leading spaces
+  TODO: Should change this to strip leading and trailing
+
+
+
+### timestamp_to_gmt/1
+### timestamp_to_local/1
+### timestamp/0
+### to_atom/1
+> Converts anything into a 'atom()'.  
+  WARNING: Can create new atoms
+
+### to_binary/1
+> Converts anything into a 'binary()'. Can convert ip addresses also.
+
+### to_binlist/1
+> Converts a binary(), string() or list() to a list of binaries
+
+### to_boolean/1
+> Converts anything into a 'integer()' or 'error'.
+
+### to_existing_atom/1
+> Converts anything into an existing atom or throws an error
+
+### to_host/1
+> Converts an IP or host to a binary host value
+
+### to_host/2
+> Converts an IP or host to a binary host value.
+  If 'IsUri' and it is an IPv6 address, it will be enclosed in '[' and ']'
+
+### to_integer/1
+> Converts anything into a 'integer()' or 'error'.
+
+### to_ip/1
+> Converts a 'list()' or 'binary()' into a 'inet:ip_address()' or 'error'.
+
+### to_list/1
+> Converts anything into a 'string()'.
+
+### to_lower/1
+> converts a 'string()' or 'binary()' to a lower 'binary()'.
+
+### to_map/1
+> If input is a map, return the map.  If it is a list, return a map from the list
+
+### to_upper/1
+> converts a 'string()' or 'binary()' to an upper 'binary()'.
+
+### uid/0
+
+### unquote/1
+> Removes double quotes
+  NOTE: Does this work?
+
+### uuid_4122/0
+### words/1

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,106 @@
+# nklib_util
+
+
+
+### append_max/3
+### apply/3
+### bin_last/2
+### bjoin/1
+### bjoin/2
+### call/2
+### call/3
+### cancel_timer/1
+### capitalize/1
+### defaults/2
+### delete/2
+### demonitor/1
+### ensure_all_started/2
+### extract/2
+### filter_values/2
+### filtermap/2
+### get_binary/2
+### get_binary/3
+### get_integer/2
+### get_integer/3
+### get_list/2
+### get_list/3
+### get_value/2
+### get_value/3
+### gmt_to_timestamp/1
+### hash/1
+### hash36/1
+### hex/1
+### is_string/1
+### keys/1
+### l_timestamp_to_float/1
+### l_timestamp/0
+### lhash/1
+### local_to_timestamp/1
+### luid/0
+### msg/2
+### randomize/1
+### remove_values/2
+### safe_call/3
+### sha/1
+### store_value/2
+### store_value/3
+### store_values/2
+
+### strip/1
+> Strips trailing white space  
+  NOTE: Really strips leading spaces
+  TODO: Should change this to strip leading and trailing
+
+
+
+### timestamp_to_gmt/1
+### timestamp_to_local/1
+### timestamp/0
+### to_atom/1
+> Converts anything into a 'atom()'.  
+  WARNING: Can create new atoms
+
+### to_binary/1
+> Converts anything into a 'binary()'. Can convert ip addresses also.
+
+### to_binlist/1
+> Converts a binary(), string() or list() to a list of binaries
+
+### to_boolean/1
+> Converts anything into a 'integer()' or 'error'.
+
+### to_existing_atom/1
+> Converts anything into an existing atom or throws an error
+
+### to_host/1
+> Converts an IP or host to a binary host value
+
+### to_host/2
+> Converts an IP or host to a binary host value.
+  If 'IsUri' and it is an IPv6 address, it will be enclosed in '[' and ']'
+
+### to_integer/1
+> Converts anything into a 'integer()' or 'error'.
+
+### to_ip/1
+> Converts a 'list()' or 'binary()' into a 'inet:ip_address()' or 'error'.
+
+### to_list/1
+> Converts anything into a 'string()'.
+
+### to_lower/1
+> converts a 'string()' or 'binary()' to a lower 'binary()'.
+
+### to_map/1
+> If input is a map, return the map.  If it is a list, return a map from the list
+
+### to_upper/1
+> converts a 'string()' or 'binary()' to an upper 'binary()'.
+
+### uid/0
+
+### unquote/1
+> Removes double quotes at the beginning and end.  For example: nklib_util:unquote(<<"\"JAMES\"">>) -> "JAMES"
+
+### uuid_4122/0
+### words/1

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,10 @@
 
 {deps, [
     {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.1.1"}}},
-    {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}}
+    {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}},
     %% Jiffy can be commented out, and Jsx will be used automatically:
     % {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.13.3"}}}
+    {eper, ".*", {git, "http://github.com/basho/eper.git", {tag, "0.78"}}},
+    {meck, ".*", {git, "http://github.com/basho/meck.git", {tag, "0.8.2"}}}
+
 ]}.

--- a/src/nklib.app.src
+++ b/src/nklib.app.src
@@ -1,6 +1,6 @@
 {application, nklib, [
     {description, "Nekso Standard Library"},
-    {vsn, "master"},
+    {vsn, "develop"},
     {modules, []},
     {registered, []},
     {mod, {nklib_app, []}},

--- a/src/nklib.app.src
+++ b/src/nklib.app.src
@@ -1,9 +1,0 @@
-{application, nklib, [
-    {description, "Nekso Standard Library"},
-    {vsn, "develop"},
-    {modules, []},
-    {registered, []},
-    {mod, {nklib_app, []}},
-    {applications, [kernel, stdlib]},
-    {env, []}
-]}.

--- a/src/nklib.erl
+++ b/src/nklib.erl
@@ -27,7 +27,7 @@
 -export_type([header/0, header_name/0, header_value/0]).
 -export_type([scheme/0, code/0]).
 
--export([get_env/2, get_env/3]).
+-export([get_env/2, get_env/3, get_env/4]).
 
 -include("nklib.hrl").
 
@@ -86,20 +86,28 @@
 %% ===================================================================
 
 
-%% @doc Equivalent to get_env(App, Key, undefined)
+%% @doc Equivalent to get_env("NKLIB", App, Key, undefined)
 -spec get_env(atom(), term()) ->
-	term().
+    term().
 
 get_env(App, Key) ->
-    get_env(App, Key, undefined).
+    get_env("NKLIB", App, Key, undefined).
+
+
+%% @doc Equivalent to get_env(Header, App, Key, undefined)
+-spec get_env(list(), atom(), term()) ->
+	term().
+
+get_env(Header, App, Key) ->
+    get_env(Header, App, Key, undefined).
 
 
 %% @doc Gets a environment value from the applications config values,
 %% the init line or a OS environment.
--spec get_env(atom(), term(), term()) ->
+-spec get_env(list(), atom(), term(), term()) ->
 	term().
 
-get_env(App, Key, Default) ->
+get_env(Header, App, Key, Default) ->
     case application:get_env(App, Key) of
         {ok, Val} -> 
             Val; 
@@ -118,7 +126,7 @@ get_env(App, Key, Default) ->
                 {ok, [[Val]]} -> 
                     list_to_binary(Val);
                 _ ->
-                    EnvKey = "NKCORE_" ++ 
+                    EnvKey = Header ++ "_" ++ 
                              string:to_upper(nklib_util:to_list(Key)),
                     case os:getenv(EnvKey) of
                         false -> Default;

--- a/src/nklib_code.erl
+++ b/src/nklib_code.erl
@@ -23,7 +23,7 @@
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
 -export([expression/1, getter/2, fun_expr/4, call_expr/4, callback_expr/3]).
--export([case_expr/5, case_expr_ok/4, compile/2, write/3]).
+-export([case_expr/5, case_expr_ok/5, compile/2, write/3]).
 -export([get_funs/1]).
 
 
@@ -138,11 +138,11 @@ case_expr(Mod, Fun, Arity, Vers, NextCode) ->
 %%     Other -> Other
 %% end
 %% Vers represents the suffix to use in the variable names.
--spec case_expr_ok(atom(), atom(), integer(),  
+-spec case_expr_ok(atom(), atom(), integer(), integer(),  
                [erl_syntax:syntaxTree()]) ->
     erl_syntax:syntaxTree().
 
-case_expr_ok(Mod, Fun, Vers, NextCode) ->
+case_expr_ok(Mod, Fun, 2, Vers, NextCode) ->
     erl_syntax:case_expr(
         call_expr(Mod, Fun, 2, Vers),
         [

--- a/src/nklib_config.erl
+++ b/src/nklib_config.erl
@@ -62,7 +62,8 @@
     #{
         return => map|list,         % Default is list
         path => binary(),           % Returned in errors
-        defaults => map() | list()
+        defaults => map() | list(),
+        mandatory => [atom()]
     }.
 
 
@@ -346,7 +347,7 @@ parse_config([], OK, NoOK, Syntax, #{defaults:=Defaults}=Opts) ->
             parse_config([], OK2, NoOK, Syntax, maps:remove(defaults, Opts));
         {ok, _, DefNoOK} ->
             lager:warning("Error parsing in defaults: ~p", [Defaults]),
-            {error, {no_pk, DefNoOK}};
+            {error, {no_ok, DefNoOK}};
         {error, Error} ->
             lager:warning("Error parsing in defaults: ~p", [Defaults]),
             {error, Error}
@@ -355,11 +356,17 @@ parse_config([], OK, NoOK, Syntax, #{defaults:=Defaults}=Opts) ->
 parse_config([], OK, NoOK, _Syntax, Opts) ->
     OK2 = lists:reverse(OK),
     NoOK2 = lists:reverse(NoOK),
-    case Opts of
-        #{return:=map} ->
-            {ok, maps:from_list(OK2), maps:from_list(NoOK)};
-        _ ->
-            {ok, OK2, NoOK2}
+    Mandatory = maps:get(mandatory, Opts, []),
+    case check_mandatory(Mandatory, OK) of
+        ok ->
+            case Opts of
+                #{return:=map} ->
+                    {ok, maps:from_list(OK2), maps:from_list(NoOK)};
+                _ ->
+                    {ok, OK2, NoOK2}
+            end;
+        {missing, Key} ->
+            {error, {missing_mandatory_field, Key}}
     end;
 
 parse_config([{Key, Val}|Rest], OK, NoOK, Syntax, Opts) ->
@@ -466,6 +473,18 @@ throw_syntax_error(Key, #{path:=Path}) ->
 
 throw_syntax_error(Key, _) ->
     throw({syntax_error, nklib_util:to_binary(Key)}).
+
+
+
+%% @private
+check_mandatory([], _) ->
+    ok;
+
+check_mandatory([Key|Rest], All) ->
+    case lists:keymember(Key, 1, All) of
+        true -> check_mandatory(Rest, All);
+        false -> {missing, Key}
+    end.
 
 
 %% @private

--- a/src/nklib_config.erl
+++ b/src/nklib_config.erl
@@ -344,6 +344,9 @@ parse_config([], OK, NoOK, Syntax, #{defaults:=Defaults}=Opts) ->
         {ok, Defaults2, []} ->
             OK2 = nklib_util:defaults(OK, Defaults2),
             parse_config([], OK2, NoOK, Syntax, maps:remove(defaults, Opts));
+        {ok, _, DefNoOK} ->
+            lager:warning("Error parsing in defaults: ~p", [Defaults]),
+            {error, {no_pk, DefNoOK}};
         {error, Error} ->
             lager:warning("Error parsing in defaults: ~p", [Defaults]),
             {error, Error}

--- a/src/nklib_gen_server.erl
+++ b/src/nklib_gen_server.erl
@@ -22,15 +22,33 @@
 -module(nklib_gen_server).
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
--export([init/4, init/5, handle_call/5, handle_call/6, handle_cast/4, handle_cast/5,
-         handle_info/4, handle_info/5, terminate/4, terminate/5, 
-         code_change/5, code_change/6, handle_any/5]).
+-export([init/4, init/5]).
+-export([handle_call/5, handle_call/6, handle_call/7]).
+-export([handle_cast/4, handle_cast/5, handle_cast/6]).
+-export([handle_info/4, handle_info/5, handle_info/6]).
+-export([terminate/4, terminate/5, code_change/5, code_change/6]).
+-export([handle_any/5, handle_any/6]).
 -include("nklib.hrl").
 
 
 %% ===================================================================
 %% Types
 %% ===================================================================
+
+-type reply() ::
+    {reply, term(), tuple()} |
+    {reply, term(), tuple(), timeout() | hibernate} |
+    {noreply, tuple()} |
+    {noreply, tuple(), timeout() | hibernate} |
+    {stop, term(), term(), tuple()} |
+    {stop, term(), tuple()}.
+
+
+-type noreply() ::
+    {noreply, tuple()} |
+    {noreply, tuple(), timeout() | hibernate} |
+    {stop, term(), tuple()}.
+
 
 
 
@@ -67,35 +85,34 @@ init(Fun, Arg, State, PosMod, PosUser) ->
     end.
 
 
-%% @private
+%% @private Default Fun and Timeout
 -spec handle_call(term(), {pid(), term()}, tuple(), pos_integer(), pos_integer()) ->
-    {reply, term(), tuple()} |
-    {reply, term(), tuple(), timeout() | hibernate} |
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), term(), tuple()} |
-    {stop, term(), tuple()}.
+    reply().
 
 handle_call(Msg, From, State, PosMod, PosUser) ->
-    handle_call(handle_call, Msg, From, State, PosMod, PosUser).
+    handle_call(handle_call, Msg, From, State, PosMod, PosUser, undefined).
+
+
+%% @private Default Timeout
+-spec handle_call(atom(), term(), {pid(), term()}, tuple(), 
+                  pos_integer(), pos_integer()) ->
+    reply().
+
+handle_call(Fun, Msg, From, State, PosMod, PosUser) ->
+    handle_call(Fun, Msg, From, State, PosMod, PosUser, undefined).
 
 
 %% @private
 -spec handle_call(atom(), term(), {pid(), term()}, tuple(), 
-                  pos_integer(), pos_integer()) ->
-    {reply, term(), tuple()} |
-    {reply, term(), tuple(), timeout() | hibernate} |
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), term(), tuple()} |
-    {stop, term(), tuple()}.
+                  pos_integer(), pos_integer(), pos_integer()) ->
+    reply().
 
-handle_call(Fun, Msg, From, State, PosMod, PosUser) ->
+handle_call(Fun, Msg, From, State, PosMod, PosUser, PosTimeout) ->
     SubMod = element(PosMod, State),
     User = element(PosUser, State),
     case erlang:function_exported(SubMod, Fun, 3) of
         true ->
-            proc_reply(SubMod:Fun(Msg, From, User), PosUser, State);
+            proc_reply(SubMod:Fun(Msg, From, User), PosUser, PosTimeout, State);
         false ->
             {noreply, State}
     end.
@@ -103,26 +120,30 @@ handle_call(Fun, Msg, From, State, PosMod, PosUser) ->
 
 %% @private
 -spec handle_cast(term(), tuple(), pos_integer(), pos_integer()) ->
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), tuple()}.
+    noreply().
 
 handle_cast(Msg, State, PosMod, PosUser) ->
-    handle_cast(handle_cast, Msg, State, PosMod, PosUser).
+    handle_cast(handle_cast, Msg, State, PosMod, PosUser, undefined).
 
 
 %% @private
 -spec handle_cast(atom(), term(), tuple(), pos_integer(), pos_integer()) ->
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), tuple()}.
+    noreply().
 
 handle_cast(Fun, Msg, State, PosMod, PosUser) ->
+    handle_cast(Fun, Msg, State, PosMod, PosUser, undefined).
+
+
+%% @private
+-spec handle_cast(atom(), term(), tuple(), pos_integer(), pos_integer(), pos_integer()) ->
+    noreply().
+
+handle_cast(Fun, Msg, State, PosMod, PosUser, PosTimeout) ->
     SubMod = element(PosMod, State),
     User = element(PosUser, State),
     case erlang:function_exported(SubMod, Fun, 2) of
         true ->
-            proc_reply(SubMod:Fun(Msg, User), PosUser, State);
+            proc_reply(SubMod:Fun(Msg, User), PosUser, PosTimeout, State);
         false ->
             {noreply, State}
     end.
@@ -130,26 +151,30 @@ handle_cast(Fun, Msg, State, PosMod, PosUser) ->
 
 %% @private
 -spec handle_info(term(), tuple(), pos_integer(), pos_integer()) ->
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), tuple()}.
+    noreply().
 
 handle_info(Msg, State, PosMod, PosUser) ->
-    handle_info(handle_info, Msg, State, PosMod, PosUser).
+    handle_info(handle_info, Msg, State, PosMod, PosUser, undefined).
 
 
 %% @private
 -spec handle_info(atom(), term(), tuple(), pos_integer(), pos_integer()) ->
-    {noreply, tuple()} |
-    {noreply, tuple(), timeout() | hibernate} |
-    {stop, term(), tuple()}.
+    noreply().
 
 handle_info(Fun, Msg, State, PosMod, PosUser) ->
+    handle_info(Fun, Msg, State, PosMod, PosUser, undefined).
+
+
+%% @private
+-spec handle_info(atom(), term(), tuple(), pos_integer(), pos_integer(), pos_integer()) ->
+    noreply().
+
+handle_info(Fun, Msg, State, PosMod, PosUser, PosTimeout) ->
     SubMod = element(PosMod, State),
     User = element(PosUser, State),
     case erlang:function_exported(SubMod, Fun, 2) of
         true ->
-            proc_reply(SubMod:Fun(Msg, User), PosUser, State);
+            proc_reply(SubMod:Fun(Msg, User), PosUser, PosTimeout, State);
         false ->
             {noreply, State}
     end.
@@ -208,7 +233,6 @@ terminate(Fun, Reason, State, PosMod, PosUser) ->
 
 %% @private
 -spec handle_any(atom(), list(), tuple(), pos_integer(), pos_integer()) ->
-    ok |
     {ok, tuple()} |
     {ok, term(), tuple()} |
     {error, term(), tuple()} |
@@ -216,28 +240,48 @@ terminate(Fun, Reason, State, PosMod, PosUser) ->
     term().
 
 handle_any(Fun, Args, State, PosMod, PosUser) ->
+    handle_any(Fun, Args, State, PosMod, PosUser, undefined).
+
+
+%% @private
+-spec handle_any(atom(), list(), tuple(), pos_integer(), pos_integer(), pos_integer()) ->
+    {ok, tuple()} |
+    {ok, term(), tuple()} |
+    {error, term(), tuple()} |
+    {error, term(), term(), tuple()} |
+    term().
+
+handle_any(Fun, Args, State, PosMod, PosUser, PosTimeout) ->
     SubMod = element(PosMod, State),
     User = element(PosUser, State),
     Args1 = Args++[User],
     case erlang:function_exported(SubMod, Fun, length(Args1)) of
         true ->
-            proc_reply(apply(SubMod, Fun, Args1), PosUser, State);
+            proc_reply(apply(SubMod, Fun, Args1), PosUser, PosTimeout, State);
         false ->
             ok
     end.
 
 
 %% @private
-proc_reply(Term, PosUser, State) ->
+proc_reply(Term, PosUser, PosTimeout, State) ->
     case Term of
         {reply, Reply, User1} ->
-            {reply, Reply, setelement(PosUser, State, User1)};
-        {reply, Reply, User1, Timeout} ->
+            Timeout = case PosTimeout of
+                undefined -> infinity;
+                _ -> element(PosTimeout, State)
+            end,
             {reply, Reply, setelement(PosUser, State, User1), Timeout};
+        {reply, Reply, User1, Timeout1} ->
+            {reply, Reply, setelement(PosUser, State, User1), Timeout1};
         {noreply, User1} ->
-            {noreply, setelement(PosUser, State, User1)};
-        {noreply, User1, Timeout} ->
+            Timeout = case PosTimeout of
+                undefined -> infinity;
+                _ -> element(PosTimeout, State)
+            end,
             {noreply, setelement(PosUser, State, User1), Timeout};
+        {noreply, User1, Timeout1} ->
+            {noreply, setelement(PosUser, State, User1), Timeout1};
         {stop, Reason, User1} ->
             {stop, Reason, setelement(PosUser, State, User1)};
         {stop, Reason, Reply, User1} ->

--- a/src/nklib_gen_server.erl
+++ b/src/nklib_gen_server.erl
@@ -245,6 +245,7 @@ handle_any(Fun, Args, State, PosMod, PosUser) ->
 
 %% @private
 -spec handle_any(atom(), list(), tuple(), pos_integer(), pos_integer(), pos_integer()) ->
+    nklib_not_exported |
     {ok, tuple()} |
     {ok, term(), tuple()} |
     {error, term(), tuple()} |
@@ -259,7 +260,7 @@ handle_any(Fun, Args, State, PosMod, PosUser, PosTimeout) ->
         true ->
             proc_reply(apply(SubMod, Fun, Args1), PosUser, PosTimeout, State);
         false ->
-            ok
+            nklib_not_exported
     end.
 
 

--- a/src/nklib_gen_server.erl
+++ b/src/nklib_gen_server.erl
@@ -250,6 +250,10 @@ proc_reply(Term, PosUser, State) ->
             {error, Error, setelement(PosUser, State, User1)};
         {error, Error, Reply, User1} ->
             {error, Error, Reply, setelement(PosUser, State, User1)};
+        {Class, User1} ->
+            {Class, setelement(PosUser, State, User1)};
+        {Class, Msg, User1} ->
+            {Class, Msg, setelement(PosUser, State, User1)};
         Other ->
             Other
     end.

--- a/src/nklib_gen_server.erl
+++ b/src/nklib_gen_server.erl
@@ -287,18 +287,25 @@ proc_reply(Term, PosUser, PosTimeout, State) ->
             {stop, Reason, setelement(PosUser, State, User1)};
         {stop, Reason, Reply, User1} ->
             {stop, Reason, Reply, setelement(PosUser, State, User1)};
-        {ok, User1} ->
-            {ok, setelement(PosUser, State, User1)};
-        {ok, Reply, User1} ->
-            {ok, Reply, setelement(PosUser, State, User1)};
-        {error, Error, User1} ->
-            {error, Error, setelement(PosUser, State, User1)};
-        {error, Error, Reply, User1} ->
-            {error, Error, Reply, setelement(PosUser, State, User1)};
-        {Class, User1} ->
-            {Class, setelement(PosUser, State, User1)};
-        {Class, Msg, User1} ->
-            {Class, Msg, setelement(PosUser, State, User1)};
+
+        _ when is_tuple(Term) ->
+            User1 = element(size(Term), Term),
+            setelement(size(Term), Term, setelement(PosUser, State, User1));
+
+
+        % {ok, User1} ->
+        %     {ok, setelement(PosUser, State, User1)};
+        % {ok, Reply, User1} ->
+        %     {ok, Reply, setelement(PosUser, State, User1)};
+        % {error, Error, User1} ->
+        %     {error, Error, setelement(PosUser, State, User1)};
+        % {error, Error, Reply, User1} ->
+        %     {error, Error, Reply, setelement(PosUser, State, User1)};
+        % {Class, User1} ->
+        %     {Class, setelement(PosUser, State, User1)};
+        % {Class, Msg, User1} ->
+        %     {Class, Msg, setelement(PosUser, State, User1)};
+
         Other ->
             Other
     end.

--- a/src/nklib_util.erl
+++ b/src/nklib_util.erl
@@ -683,16 +683,24 @@ to_binlist(Bin) when is_binary(Bin) -> [Bin];
 to_binlist(Term) -> [to_binary(Term)].
 
 
-%% @doc URI Strips trailing white space
+%% @doc URI Strips leading and trailing white space
 -spec strip(list()|binary()) ->
     list().
 
 strip(Bin) when is_binary(Bin) -> strip(binary_to_list(Bin));
-strip([32|Rest]) -> strip(Rest);
-strip([13|Rest]) -> strip(Rest);
-strip([10|Rest]) -> strip(Rest);
-strip([9|Rest]) -> strip(Rest);
-strip(Rest) -> Rest.
+strip([32|Rest]) -> strip(Rest);  %% 32 = sapce
+strip([13|Rest]) -> strip(Rest);  %% 13 = CR
+strip([10|Rest]) -> strip(Rest);  %% 10 = LF
+strip([9|Rest]) -> strip(Rest);   %% 9 = TAB
+strip(Rest) -> striptail(lists:reverse(Rest)).
+
+striptail(Bin) when is_binary(Bin) -> striptail(binary_to_list(Bin));
+striptail([32|Rest]) -> striptail(Rest);  %% 32 = sapce
+striptail([13|Rest]) -> striptail(Rest);  %% 13 = CR
+striptail([10|Rest]) -> striptail(Rest);  %% 10 = LF
+striptail([9|Rest]) -> striptail(Rest);   %% 9 = TAB
+striptail(Rest) -> lists:reverse(Rest).
+
 
 
 %% @doc Removes doble quotes

--- a/src/nklib_util.erl
+++ b/src/nklib_util.erl
@@ -97,7 +97,7 @@ ensure_all_started(Application, Type, Started) ->
 %% @doc Like gen_server:call/3 but traps exceptions
 %% For timeouts: {error, {exit, {{timeout, _}, _}}}
 -spec call(atom()|pid(), term(), #{timeout=>pos_integer()|infinity}) ->
-    term() | {error, timeout | {exit|error|throw, {term(), list()}}}.
+    term() | {error, {exit|error|throw, {term(), list()}}}.
 
 call(Dest, Msg, Opts) ->
     Timeout = maps:get(timeout, Opts, 5000),

--- a/src/nklib_util.erl
+++ b/src/nklib_util.erl
@@ -22,7 +22,7 @@
 -module(nklib_util).
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
--export([ensure_all_started/2, call/3, apply/3, safe_call/3]).
+-export([ensure_all_started/2, call/2, call/3, apply/3, safe_call/3]).
 -export([luid/0, lhash/1, uid/0, uuid_4122/0, hash/1, hash36/1, sha/1]).
 -export([timestamp/0, l_timestamp/0, l_timestamp_to_float/1]).
 -export([timestamp_to_local/1, timestamp_to_gmt/1]).
@@ -94,13 +94,20 @@ ensure_all_started(Application, Type, Started) ->
     end.
 
 
-%% @doc Like gen_server:call/3 but traps exceptions
-%% For timeouts: {error, {exit, {{timeout, _}, _}}}
--spec call(atom()|pid(), term(), #{timeout=>pos_integer()|infinity}) ->
+%% @doc See call/3
+-spec call(atom()|pid(), term()) ->
     term() | {error, {exit|error|throw, {term(), list()}}}.
 
-call(Dest, Msg, Opts) ->
-    Timeout = maps:get(timeout, Opts, 5000),
+call(Dest, Msg) ->
+    call(Dest, Msg, 5000).
+
+
+%% @doc Like gen_server:call/3 but traps exceptions
+%% For timeouts: {error, {exit, {{timeout, _}, _}}}
+-spec call(atom()|pid(), term(), timeout() | infinity) ->
+    term() | {error, {exit|error|throw, {term(), list()}}}.
+
+call(Dest, Msg, Timeout) ->
     try
         gen_server:call(Dest, Msg, Timeout)
     catch

--- a/src/nklib_util.erl
+++ b/src/nklib_util.erl
@@ -22,7 +22,7 @@
 -module(nklib_util).
 -author('Carlos Gonzalez <carlosj.gf@gmail.com>').
 
--export([ensure_all_started/2, call/3, safe_call/3]).
+-export([ensure_all_started/2, call/3, apply/3, safe_call/3]).
 -export([luid/0, lhash/1, uid/0, uuid_4122/0, hash/1, hash36/1, sha/1]).
 -export([timestamp/0, l_timestamp/0, l_timestamp_to_float/1]).
 -export([timestamp_to_local/1, timestamp_to_gmt/1]).
@@ -107,6 +107,25 @@ call(Dest, Msg, Opts) ->
         Class:Error ->
             {error, {Class, {Error, erlang:get_stacktrace()}}}
     end.
+
+
+%% @private
+-spec apply(atom(), atom(), list()) ->
+    term() | not_exported | {error, {exit|error|throw, {term(), list()}}}.
+
+apply(Mod, Fun, Args) ->
+    try
+        case erlang:function_exported(Mod, Fun, length(Args)) of
+            false ->
+                not_exported;
+            true ->
+                erlang:apply(Mod, Fun, Args)
+        end
+    catch
+        Class:Error ->
+            {error, {Class, {Error, erlang:get_stacktrace()}}}
+    end.
+
 
 
 %% @doc Safe gen_server:call/3


### PR DESCRIPTION
nklib_util:strip was only striping (space, CR, LF, TAB) from the front
of a binary or string.  I added a list:reverse then call
nklib_util:striptail that does the same to the end, then returns the
list (reversed again)